### PR TITLE
Add text selector for playwright

### DIFF
--- a/src/pages/Content/ActionList.tsx
+++ b/src/pages/Content/ActionList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { getBestSelectorForAction } from './selector';
+import { ScriptType } from '../types';
 
 import ActionListStyle from './ActionList.css';
 
@@ -25,7 +26,9 @@ function ActionListItem({
           (action.selectors.text?.length ?? -1) < 75 ? (
             <span>"{action.selectors.text}"</span>
           ) : (
-            <span className="mono">{getBestSelectorForAction(action)}</span>
+            <span className="mono">
+              {getBestSelectorForAction(action, ScriptType.Playwright)}
+            </span>
           )}
         </>
       ) : action.type === 'hover' ? (
@@ -38,7 +41,9 @@ function ActionListItem({
           (action.selectors.text?.length ?? -1) < 75 ? (
             <span>"{action.selectors.text}"</span>
           ) : (
-            <span className="mono">{getBestSelectorForAction(action)}</span>
+            <span className="mono">
+              {getBestSelectorForAction(action, ScriptType.Playwright)}
+            </span>
           )}
         </>
       ) : action.type === 'load' ? (
@@ -56,13 +61,18 @@ function ActionListItem({
               : action.value}
             "
           </span>{' '}
-          on <span className="mono">{getBestSelectorForAction(action)}</span>
+          on{' '}
+          <span className="mono">
+            {getBestSelectorForAction(action, ScriptType.Playwright)}
+          </span>
         </>
       ) : action.type === 'keydown' ? (
         <>
           <span className="em-text">Press</span>{' '}
           <span className="mono">"{action.key}"</span> on{' '}
-          <span className="mono">{getBestSelectorForAction(action)}</span>
+          <span className="mono">
+            {getBestSelectorForAction(action, ScriptType.Playwright)}
+          </span>
         </>
       ) : action.type === 'resize' ? (
         <>
@@ -98,7 +108,7 @@ export default function ActionList({ actions }: { actions: Action[] }) {
   return (
     <>
       <style>{ActionListStyle}</style>
-      <div className="ActionList" data-testId="action-list">
+      <div className="ActionList" data-testid="action-list">
         {actions
           .filter((action) =>
             [

--- a/src/pages/Content/CodeGen.tsx
+++ b/src/pages/Content/CodeGen.tsx
@@ -12,25 +12,25 @@ const truncateText = (str: string, maxLen: number) => {
   return `${str.substring(0, maxLen)}${str.length > maxLen ? '...' : ''}`;
 };
 
-function describeAction(action: Action) {
-
+function describeAction(action: Action, lib: ScriptType) {
   return action?.type === ActionType.Click
     ? `Click on <${action.tagName.toLowerCase()}> ${
         action.selectors.text != null && action.selectors.text.length > 0
           ? `"${truncateText(action.selectors.text.replace('\n', ' '), 25)}"`
-          : getBestSelectorForAction(action)
+          : getBestSelectorForAction(action, lib)
       }`
     : action?.type === ActionType.Hover
     ? `Hover over <${action.tagName.toLowerCase()}> ${
         action.selectors.text != null && action.selectors.text.length > 0
           ? `"${truncateText(action.selectors.text.replace('\n', ' '), 25)}"`
-          : getBestSelectorForAction(action)
+          : getBestSelectorForAction(action, lib)
       }`
     : action?.type === ActionType.Input
     ? `Fill "${
         action.value
       }" on <${action.tagName.toLowerCase()}> ${getBestSelectorForAction(
-        action
+        action,
+        lib
       )}`
     : action?.type == ActionType.Keydown
     ? `Press ${action.key} on ${action.tagName.toLowerCase()}`
@@ -76,12 +76,12 @@ export const isSupportedActionType = (actionType: any) => {
     ActionType.FullScreenshot,
     ActionType.AwaitText,
   ].includes(actionType);
-}
+};
 
 export function genCode(
   actions: Action[],
   showComments: boolean = true,
-  lib: ScriptType = 'playwright' as ScriptType,
+  lib: ScriptType = 'playwright' as ScriptType
 ): string {
   const scriptBuilder =
     lib === 'playwright'
@@ -91,13 +91,13 @@ export function genCode(
   for (let i = 0; i < actions.length; i++) {
     const action = actions[i];
 
-    if (!(isSupportedActionType(action.type))) {
+    if (!isSupportedActionType(action.type)) {
       continue;
     }
 
     const nextAction = actions[i + 1];
     const causesNavigation = nextAction?.type === ActionType.Navigate;
-    const actionDescription = `${describeAction(action)}${
+    const actionDescription = `${describeAction(action, lib)}${
       causesNavigation && lib === 'puppeteer' ? ' and await navigation' : ''
     }`;
 
@@ -114,7 +114,7 @@ export function genCode(
       action.type === ActionType.Keydown ||
       action.type === ActionType.Hover
     ) {
-      bestSelector = getBestSelectorForAction(action);
+      bestSelector = getBestSelectorForAction(action, lib);
       if (bestSelector === null) {
         throw new Error(`Cant generate selector for action ${action}`);
       }

--- a/src/pages/Content/ControlBar.tsx
+++ b/src/pages/Content/ControlBar.tsx
@@ -36,7 +36,7 @@ const ActionButton = ({
   label: String;
   testId?: String;
 }) => (
-  <div className="ActionButton" onClick={onClick} data-testId={testId}>
+  <div className="ActionButton" onClick={onClick} data-testid={testId}>
     <div>
       <div
         style={{
@@ -59,11 +59,13 @@ function RenderActionText({ action }: { action: Action }) {
     <>
       {action?.type === 'click'
         ? `Click on ${action.tagName.toLowerCase()} ${getBestSelectorForAction(
-            action
+            action,
+            ScriptType.Playwright
           )}`
         : action.type === 'hover'
         ? `Hover over ${action.tagName.toLowerCase()} ${getBestSelectorForAction(
-            action
+            action,
+            ScriptType.Playwright
           )}`
         : action?.type === 'input'
         ? `Fill "${
@@ -71,7 +73,8 @@ function RenderActionText({ action }: { action: Action }) {
               ? '*'.repeat(action?.value?.length ?? 0)
               : action.value
           }" on ${action.tagName.toLowerCase()} ${getBestSelectorForAction(
-            action
+            action,
+            ScriptType.Playwright
           )}`
         : action?.type == 'keydown'
         ? `Press ${action.key} on ${action.tagName.toLowerCase()}`
@@ -107,8 +110,12 @@ export default function ControlBar({ onExit }: { onExit: () => void }) {
   const [actions, setActions] = useState<Action[]>([]);
 
   const [showAllActions, setShowAllActions] = useState<boolean>(false);
-  const [showActionsMode, setShowActionsMode] = useState<ActionsMode>(ActionsMode.Code);
-  const [showScriptType, setScriptType] = useState<ScriptType>(ScriptType.Playwright);
+  const [showActionsMode, setShowActionsMode] = useState<ActionsMode>(
+    ActionsMode.Code
+  );
+  const [showScriptType, setScriptType] = useState<ScriptType>(
+    ScriptType.Playwright
+  );
 
   const [copyCodeConfirm, setCopyCodeConfirm] = useState<boolean>(false);
   const [screenshotConfirm, setScreenshotConfirm] = useState<boolean>(false);
@@ -192,15 +199,21 @@ export default function ControlBar({ onExit }: { onExit: () => void }) {
   }, []);
 
   const rect = hoveredElement?.getBoundingClientRect();
-  const displayedSelector = getBestSelectorForAction({
-    type: ActionType.Click,
-    tagName: hoveredElement?.tagName ?? '',
-    inputType: undefined,
-    value: undefined,
-    selectors: hoveredElementSelectors || {},
-    timestamp: 0,
-    isPassword: false,
-  });
+  const displayedSelector = getBestSelectorForAction(
+    {
+      type: ActionType.Click,
+      tagName: hoveredElement?.tagName ?? '',
+      inputType: undefined,
+      value: undefined,
+      selectors: hoveredElementSelectors || {},
+      timestamp: 0,
+      isPassword: false,
+      hasOnlyText:
+        hoveredElement?.children?.length === 0 &&
+        hoveredElement?.innerText?.length > 0,
+    },
+    ScriptType.Playwright
+  );
 
   if (isOpen === false) {
     return <> </>;
@@ -223,7 +236,7 @@ export default function ControlBar({ onExit }: { onExit: () => void }) {
           <div className="p-4">
             <div className="d-flex justify-between mb-2">
               <div className="text-xl">
-                <span className="mr-2" data-testId="recording-finished">
+                <span className="mr-2" data-testid="recording-finished">
                   Recording Finished!
                 </span>
                 🎉
@@ -296,16 +309,21 @@ export default function ControlBar({ onExit }: { onExit: () => void }) {
               <div className="mb-4">
                 <span
                   className="text-sm link-button mr-2"
-                  data-testId={`show-${
-                    showActionsMode === ActionsMode.Actions ? ActionsMode.Code : ActionsMode.Actions
+                  data-testid={`show-${
+                    showActionsMode === ActionsMode.Actions
+                      ? ActionsMode.Code
+                      : ActionsMode.Actions
                   }`}
                   onClick={() => {
                     setShowActionsMode(
-                      showActionsMode === ActionsMode.Actions ? ActionsMode.Code : ActionsMode.Actions
+                      showActionsMode === ActionsMode.Actions
+                        ? ActionsMode.Code
+                        : ActionsMode.Actions
                     );
                   }}
                 >
-                  Show {showActionsMode === ActionsMode.Actions ? 'Code' : 'Actions'}
+                  Show{' '}
+                  {showActionsMode === ActionsMode.Actions ? 'Code' : 'Actions'}
                 </span>
                 {!isFinished && (
                   <span
@@ -373,8 +391,12 @@ export default function ControlBar({ onExit }: { onExit: () => void }) {
               </div>
             </div>
 
-            {showActionsMode === ActionsMode.Code && <CodeGen actions={actions} library={showScriptType} />}
-            {showActionsMode === ActionsMode.Actions && <ActionList actions={actions} />}
+            {showActionsMode === ActionsMode.Code && (
+              <CodeGen actions={actions} library={showScriptType} />
+            )}
+            {showActionsMode === ActionsMode.Actions && (
+              <ActionList actions={actions} />
+            )}
           </div>
         )}
       </div>

--- a/src/pages/Content/recorder.ts
+++ b/src/pages/Content/recorder.ts
@@ -50,6 +50,7 @@ function buildBaseAction(
     inputType: target instanceof HTMLInputElement ? target.type : undefined,
     selectors: genSelectors(target) ?? {},
     timestamp: event.timeStamp,
+    hasOnlyText: target.children.length === 0 && target.innerText.length > 0,
     value: undefined,
   };
 }

--- a/src/pages/types/index.ts
+++ b/src/pages/types/index.ts
@@ -30,7 +30,8 @@ export class BaseAction {
   selectors: { [key: string]: string | null };
   timestamp: number;
   isPassword: boolean;
-};
+  hasOnlyText: boolean; // If the element only has text content inside (hint to use text selector)
+}
 
 class KeydownAction extends BaseAction {
   type: ActionType.Keydown;
@@ -79,15 +80,16 @@ export class ResizeAction extends BaseAction {
   type: ActionType.Resize;
   width: number;
   height: number;
-};
+}
 
-export type Action = KeydownAction |
-  InputAction |
-  ClickAction |
-  HoverAction |
-  LoadAction |
-  NavigateAction |
-  WheelAction |
-  FullScreenshotAction |
-  AwaitTextAction |
-  ResizeAction;
+export type Action =
+  | KeydownAction
+  | InputAction
+  | ClickAction
+  | HoverAction
+  | LoadAction
+  | NavigateAction
+  | WheelAction
+  | FullScreenshotAction
+  | AwaitTextAction
+  | ResizeAction;


### PR DESCRIPTION
Allows for Playwright code to use text-based selectors if other selectors aren't available. No support for Puppeteer yet, requires a bit of xpath work to make it work for Puppeteer unfortunately.