### PR TITLE
Fix duplicate id crashing bug and invalid multiline comment bug

### DIFF
--- a/src/pages/builders/index.ts
+++ b/src/pages/builders/index.ts
@@ -90,13 +90,13 @@ export class ActionContext extends BaseAction {
       case ActionType.Click:
         return `Click on <${tagName.toLowerCase()}> ${
           selectors.text != null && selectors.text.length > 0
-            ? `"${truncateText(selectors.text.replace('\n', ' '), 25)}"`
+            ? `"${truncateText(selectors.text.replace(/\s/g, ' '), 25)}"`
             : getBestSelectorForAction(this.action, this.scriptType)
         }`;
       case ActionType.Hover:
         return `Hover over <${tagName.toLowerCase()}> ${
           selectors.text != null && selectors.text.length > 0
-            ? `"${truncateText(selectors.text.replace('\n', ' '), 25)}"`
+            ? `"${truncateText(selectors.text.replace(/\s/g, ' '), 25)}"`
             : getBestSelectorForAction(this.action, this.scriptType)
         }`;
       case ActionType.Input:

--- a/src/pages/builders/selector.ts
+++ b/src/pages/builders/selector.ts
@@ -80,13 +80,18 @@ export default function genSelectors(element: HTMLElement | null) {
   ]);
 
   // We won't use an id selector if the id is invalid (starts with a number)
-  const idSelector =
-    isAttributesDefined(element, ['id']) && !isCharacterNumber(element.id?.[0])
-      ? // Certain apps don't have unique ids (ex. youtube)
-        finder(element, {
-          attr: (name) => name === 'id',
-        })
-      : null;
+  let idSelector = null;
+  try {
+    idSelector =
+      isAttributesDefined(element, ['id']) &&
+      !isCharacterNumber(element.id?.[0])
+        ? // Certain apps don't have unique ids (ex. youtube)
+          finder(element, {
+            attr: (name) => name === 'id',
+          })
+        : null;
+  } catch (e) {}
+
   return {
     id: idSelector,
     generalSelector,


### PR DESCRIPTION
Fixes two bugs in the current recorder:
- A page with duplicate ids on elements would have previously thrown an uncaught exception, now we return null (which isn't great, but at least isn't uncaught)
- If you select an element with multiple lines of text, we previously generated an invalid comment

Example:
<img width="474" alt="image" src="https://user-images.githubusercontent.com/2781687/164531421-4030a0ff-52b2-432a-965d-6cc3a8ef2cc9.png">

Fix:
<img width="519" alt="image" src="https://user-images.githubusercontent.com/2781687/164531537-f945a497-e4b6-4c8b-94b2-1564b476a8ac.png">
